### PR TITLE
:bug: Report actual input for when union was expected.

### DIFF
--- a/src/cast.d.ts
+++ b/src/cast.d.ts
@@ -41,7 +41,12 @@ declare type Cast<A> =
       values: Set<Primitive>;
       actual: unknown;
     }
-  | { status: "failure"; expected: "union"; variants: Cast<never>[] }
+  | {
+      status: "failure";
+      expected: "union";
+      variants: Cast<never>[];
+      actual: unknown;
+    }
   | { status: "failure"; expected: "intersection"; results: Cast<unknown>[] };
 
 declare const cast: <A>(type: Type<A>) => (input: unknown) => Cast<A>;

--- a/src/cast.js
+++ b/src/cast.js
@@ -169,7 +169,7 @@ const cast = (inputType) => {
           (variant) => variant.status === "success"
         );
         if (successes.length === 0)
-          return { status: "failure", expected: "union", variants };
+          return { status: "failure", expected: "union", variants, actual };
         const [value, ...values] = successes.flatMap((variant) => [
           variant.value,
           ...variant.values

--- a/src/cast.test.ts
+++ b/src/cast.test.ts
@@ -593,7 +593,8 @@ describe("cast", () => {
               variants: [
                 { status: "failure", expected: "number", actual: input },
                 { status: "failure", expected: "null", actual: input }
-              ]
+              ],
+              actual: input
             });
           }
         )
@@ -642,7 +643,8 @@ describe("cast", () => {
               variants: [
                 { status: "failure", expected: "number", actual: input },
                 { status: "failure", expected: "undefined", actual: input }
-              ]
+              ],
+              actual: input
             });
           }
         )
@@ -767,7 +769,8 @@ describe("cast", () => {
                 },
                 actual: input
               }
-            ]
+            ],
+            actual: input
           });
         })
       );


### PR DESCRIPTION
In case the union is empty, we will always fail. Hence, we should know what the actual input was.